### PR TITLE
fix: change NotOngoinClass message from hardcoded to variable

### DIFF
--- a/src/services/students_service.py
+++ b/src/services/students_service.py
@@ -10,10 +10,16 @@ from src.errors.students_exception import (
 from src.repositories.attendance_repository import AttendanceRepository
 from src.repositories.students_repository import StudentRepository
 from src.utils.date_handler import DateHandler
-from src.utils.schedule import Schedule
+from src.utils.schedule import Schedule, FirstClassHalf, SecondClassHalf
 
 
 class StudentService:
+
+    first_half_begin = FirstClassHalf.BEGIN.value.strftime("%H:%M")
+    first_half_end = FirstClassHalf.END.value.strftime("%H:%M")
+    second_half_begin = SecondClassHalf.BEGIN.value.strftime("%H:%M")
+    second_half_end = SecondClassHalf.END.value.strftime("%H:%M")
+
     def __init__(
         self,
         student_repository: StudentRepository = Depends(StudentRepository),
@@ -34,7 +40,9 @@ class StudentService:
         current_class = self.schedule.get_current_class()
         if current_class is None:
             raise NotOngoingLesson(
-                "Não há aula em andamento. As presenças só podem ser registradas nos intervalo entre 17:45 até 20:00 e 20:15 até 22:00"
+                "Não há aula em andamento. As presenças só podem ser registradas"
+                + f" nos intervalo entre {self.first_half_begin} até {self.first_half_end}" 
+                + f" e {self.second_half_begin} até {self.second_half_end}"
             )
 
         attendance = self.attendance_repository.get_last_with(student_id=student.id)

--- a/src/services/students_service.py
+++ b/src/services/students_service.py
@@ -15,11 +15,6 @@ from src.utils.schedule import Schedule, FirstClassHalf, SecondClassHalf
 
 class StudentService:
 
-    first_half_begin = FirstClassHalf.BEGIN.value.strftime("%H:%M")
-    first_half_end = FirstClassHalf.END.value.strftime("%H:%M")
-    second_half_begin = SecondClassHalf.BEGIN.value.strftime("%H:%M")
-    second_half_end = SecondClassHalf.END.value.strftime("%H:%M")
-
     def __init__(
         self,
         student_repository: StudentRepository = Depends(StudentRepository),
@@ -40,9 +35,7 @@ class StudentService:
         current_class = self.schedule.get_current_class()
         if current_class is None:
             raise NotOngoingLesson(
-                "Não há aula em andamento. As presenças só podem ser registradas"
-                + f" nos intervalo entre {self.first_half_begin} até {self.first_half_end}" 
-                + f" e {self.second_half_begin} até {self.second_half_end}"
+                f"Não há aula em andamento. As presenças só podem ser registradas nos intervalo entre {FirstClassHalf.begin_time_str()} até {FirstClassHalf.end_time_str()} e {SecondClassHalf.begin_time_str()} até {SecondClassHalf.end_time_str()}"
             )
 
         attendance = self.attendance_repository.get_last_with(student_id=student.id)

--- a/src/utils/schedule.py
+++ b/src/utils/schedule.py
@@ -23,10 +23,21 @@ class FirstClassHalf(enum.Enum):
     BEGIN = time(17, 45)
     END = time(18, 20)
 
+    def begin_time_str() -> str:
+        return FirstClassHalf.BEGIN.value.strftime("%H:%M")
+    
+    def end_time_str() -> str:
+        return FirstClassHalf.BEGIN.value.strftime("%H:%M")
 
 class SecondClassHalf(enum.Enum):
     BEGIN = time(20, 15)
     END = time(20, 40)
+
+    def begin_time_str() -> str:
+        return SecondClassHalf.BEGIN.value.strftime("%H:%M")
+    
+    def end_time_str() -> str:
+        return SecondClassHalf.END.value.strftime("%H:%M")
 
 
 class CourseClass:
@@ -62,8 +73,6 @@ class CourseClass:
 
 
 class Schedule:
-    def __init__(self) -> None:
-        pass
 
     def get_current_class(self) -> CourseClass | None:
         MONDAY = [

--- a/tests/integration_tests/presenca/test_cpf_number.py
+++ b/tests/integration_tests/presenca/test_cpf_number.py
@@ -59,7 +59,7 @@ class TestPresencaCpfNumber:
         assert response_body["app_exception"] == "NotOngoingLesson"
         assert (
             response_body["message"]
-            == "Não há aula em andamento. As presenças só podem ser registradas nos intervalo entre 17:45 até 20:00 e 20:15 até 22:00"
+            == f"Não há aula em andamento. As presenças só podem ser registradas nos intervalo entre {FirstClassHalf.begin_time_str()} até {FirstClassHalf.end_time_str()} e {SecondClassHalf.begin_time_str()} até {SecondClassHalf.end_time_str()}"
         )
 
     @freeze_time("2023-04-10 17:45:00")

--- a/tests/unit_tests/services/test_studants_services.py
+++ b/tests/unit_tests/services/test_studants_services.py
@@ -9,7 +9,7 @@ from src.errors.students_exception import (
 
 from src.models.students_model import CadastroAlunos, Presenca
 from src.services.students_service import StudentService
-from src.utils.schedule import CourseClass, FirstClassHalf, LateTypes
+from src.utils.schedule import CourseClass, FirstClassHalf, LateTypes, SecondClassHalf
 
 fake = Faker()
 
@@ -108,7 +108,7 @@ class TestStudentService:
         assert app_exception.type.__name__ == "NotOngoingLesson"
         assert (
             app_exception.value.message
-            == "Não há aula em andamento. As presenças só podem ser registradas nos intervalo entre 17:45 até 20:00 e 20:15 até 22:00"
+            == f"Não há aula em andamento. As presenças só podem ser registradas nos intervalo entre {FirstClassHalf.begin_time_str()} até {FirstClassHalf.end_time_str()} e {SecondClassHalf.begin_time_str()} até {SecondClassHalf.end_time_str()}"
         )
         assert app_exception.value.status_code == 400
 


### PR DESCRIPTION
#Descriçao
Essa PR faz com que a mensagem de erro de aula não ocorrendo imprima os valores das variáveis responsáveis pelo inicio e final de cada aula.